### PR TITLE
use longer key id, fix issues with Ubuntu 16.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add SBT repo
-  apt_repository: repo='deb https://dl.bintray.com/sbt/debian /' state=present
+  apt_repository: repo='deb https://dl.bintray.com/sbt/debian /' state=present update_cache=no
 - name: Add SBT repo key
-  apt_key: keyserver='hkp://keyserver.ubuntu.com:80' id='642AC823'
+  apt_key: keyserver='hkp://keyserver.ubuntu.com:80' id='2EE0EA64E40A89B84B2DF73499E82A75642AC823'
 - name: Install SBT
   apt: name=sbt state=present update_cache=yes


### PR DESCRIPTION
Issues with Ubuntu 16.04. It will not install. Issue is similar to this one:
https://discuss.newrelic.com/t/new-relic-gpg-key-is-no-longer-trusted-on-ubuntu-16-04-lts/36696/19?u=therealmarv

Also use longer key id from
http://www.scala-sbt.org/0.13/docs/Installing-sbt-on-Linux.html